### PR TITLE
Add cssselect to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 lxml
+cssselect


### PR DESCRIPTION
OS X 10.7.5
python 2.7.3

``` python
>>> from mincss.processor import Processor
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/rerb/.virtualenvs/mincss/lib/python2.7/site-packages/mincss-0.2-py2.7.egg/mincss/processor.py", line 7, in <module>
    from lxml.cssselect import CSSSelector, SelectorSyntaxError, ExpressionError
  File "/Users/rerb/.virtualenvs/mincss/lib/python2.7/site-packages/lxml/cssselect.py", line 18, in <module>
    raise ImportError('cssselect seems not to be installed. '
ImportError: cssselect seems not to be installed. See http://packages.python.org/cssselect/
```
