### PR TITLE
Fix error in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -32,8 +32,6 @@ if __name__ == '__main__':
         os.mkdir(output_dir)
     for link in p.links:
         print "FOR", link.href
-        if link.href != link.url:
-            print "url: ", link.url
         #print "BEFORE ".ljust(79, '-')
         #print link.before
         #print "AFTER ".ljust(79, '-')


### PR DESCRIPTION
run.py crashes for me right now because LinkResult.url is not set:

```
python run.py http://localhost:8888/blog/
FOR /blog/theme/static/common.css
Traceback (most recent call last):
  File "run.py", line 35, in <module>
    if link.href != link.url:
AttributeError: 'LinkResult' object has no attribute 'url'
```
