### PR TITLE
Fix an utf-8 issue in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -42,7 +42,7 @@ def run(args):
             f.write(link.after)
         before_name = 'before_' + link.href.split('/')[-1]
         with open(os.path.join(output_dir, before_name), 'w') as f:
-            f.write(link.before)
+            f.write(link.before.encode('utf-8'))
         print "Files written to", output_dir
         print
         print (


### PR DESCRIPTION
Simply fix an utf-8 issue into run.py caused by some utf-8 chars to write.
