### PR TITLE
Added classifier in setup.py to indicate Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
     ],
     install_requires=find_install_requires(),
     entry_points={'console_scripts': ['mincss=mincss.main:main']},


### PR DESCRIPTION
Given that this project supports Python 3 the inclusion of this classifier means it'll pass tests such as https://caniusepython3.com/project/mincss.
